### PR TITLE
Add missing model to public number factory

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -32,6 +32,9 @@ class SimpleNumber(BaseFactory):
 
 
 class PublicNumber(ComplexDraw):
+    class Meta:
+        model = models.RandomNumber
+
     range_min = 5
     range_max = 22
 


### PR DESCRIPTION
The factory misses the model which can result in users passing invalid
fields into the factory without noticing the issue.