### PR TITLE
Lint errors in the test folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ run: venv
 
 lint: venv
 	venv/bin/python -m pylint eas
+	venv/bin/python -m pylint tests -E


### PR DESCRIPTION
Runs pylint on the test folder but only checking for possible errors.
All items not being reported as the project is more relaxed on the
linting of the tests.