### PR TITLE
 Rename endpoint methods to descriptive names

### DIFF
--- a/eas/api.py
+++ b/eas/api.py
@@ -52,7 +52,6 @@ def create_draw(draw_type):
 @bp.route("/<string:draw_type>/<string:id_>", methods=["PUT"])
 def toss_draw(draw_type, id_):
     """Toss of a draw"""
-    serializer = _SCHEMAS[draw_type](exclude=["private_id"])
     model_class = _MODELS[draw_type]
 
     obj = model_class.get_draw_or_404(id_)
@@ -60,8 +59,7 @@ def toss_draw(draw_type, id_):
     models.db.session.add(obj)
     models.db.session.commit()
 
-    output_data, _ = serializer.dump(obj)
-    return jsonify(output_data)
+    return retrieve_draw_by_id(draw_type, id_)
 
 
 @bp.route("/<string:draw_type>/<string:id_>", methods=["GET"])

--- a/eas/api.py
+++ b/eas/api.py
@@ -36,7 +36,7 @@ def handle_invalid_usage(error):
 
 
 @bp.route("/<string:draw_type>", methods=["POST"])
-def post(draw_type):
+def create_draw(draw_type):
     """Draw creation"""
     serializer = _SCHEMAS[draw_type](strict=True)
 
@@ -50,7 +50,7 @@ def post(draw_type):
 
 
 @bp.route("/<string:draw_type>/<string:id_>", methods=["PUT"])
-def put(draw_type, id_):
+def toss_draw(draw_type, id_):
     """Toss of a draw"""
     serializer = _SCHEMAS[draw_type](exclude=["private_id"])
     model_class = _MODELS[draw_type]
@@ -65,7 +65,7 @@ def put(draw_type, id_):
 
 
 @bp.route("/<string:draw_type>/<string:id_>", methods=["GET"])
-def get(draw_type, id_):
+def retrieve_draw_by_id(draw_type, id_):
     """Retrieves a draw via its public/private id"""
     serializer = _SCHEMAS[draw_type](exclude=["private_id"])
     model_class = _MODELS[draw_type]


### PR DESCRIPTION
The endpoints should have an easier to recognize name, given that flask
uses the function name as endpoint, this commit provides meaning to each
of the functions rather that leaving them as the HTTP method that they
serve.