### PR TITLE
Use class based views to dispatch requests

### DIFF
--- a/eas/api.py
+++ b/eas/api.py
@@ -1,18 +1,9 @@
 """Defintion of the endpoints for EAS api"""
-from flask import request, Blueprint, jsonify
+from flask import request, Blueprint, jsonify, views
 
 from . import models, schemas, swagger
 
 bp = Blueprint("api", __name__)
-
-
-_SCHEMAS = {
-    "random_number": schemas.RandomNumber,
-}
-
-_MODELS = {
-    "random_number": models.RandomNumber,
-}
 
 
 @bp.route("/swagger.yaml")
@@ -35,39 +26,63 @@ def handle_invalid_usage(error):
     return response
 
 
-@bp.route("/<string:draw_type>", methods=["POST"])
-def create_draw(draw_type):
-    """Draw creation"""
-    serializer = _SCHEMAS[draw_type](strict=True)
+class BaseDrawView(views.MethodView):
+    NAME = None
+    SERIALIZER = None
+    MODEL_CLASS = None
 
-    obj, _ = serializer.load(request.get_json(force=True))
-    models.db.session.add(obj)
-    models.db.session.commit()
+    def create_draw(self, data):
+        """Creates a new draw"""
+        serializer = self.SERIALIZER(strict=True)
+        obj, _ = serializer.load(data)
+        models.db.session.add(obj)
+        models.db.session.commit()
 
-    output_data, _ = serializer.dump(obj)
-    output_data["private_id"] = obj.private_id
-    return jsonify(output_data)
+        output_data, _ = serializer.dump(obj)
+        output_data["private_id"] = obj.private_id
+        return output_data
+
+    def toss_draw(self, id_):
+        """Generates a new result of a draw"""
+        obj = self.MODEL_CLASS.query.filter_by(private_id=id_).first_or_404()
+        obj.toss()
+        models.db.session.add(obj)
+        models.db.session.commit()
+
+    def retrieve_draw(self, id_):
+        """Retrieves a draw via its public/private id"""
+        serializer = self.SERIALIZER(exclude=["private_id"])
+
+        obj = self.MODEL_CLASS.get_draw_or_404(id_)
+        output_data, _ = serializer.dump(obj)
+        return output_data
+
+    @classmethod
+    def register_urls(cls, bp_):
+        """Registers the view using its name in a blueprint"""
+        bp_.add_url_rule(f"/{cls.NAME}",
+                         view_func=cls.as_view(cls.NAME),
+                         methods=["POST"])
+        bp_.add_url_rule(f"/{cls.NAME}/<string:id_>",
+                         view_func=cls.as_view(cls.NAME + "_item"),
+                         methods=["GET", "PUT"])
+
+    def post(self):
+        output = self.create_draw(request.get_json(force=True))
+        return jsonify(output)
+
+    def put(self, id_):
+        self.toss_draw(id_)
+        return self.get(id_)
+
+    def get(self, id_):
+        return jsonify(self.retrieve_draw(id_))
 
 
-@bp.route("/<string:draw_type>/<string:id_>", methods=["PUT"])
-def toss_draw(draw_type, id_):
-    """Toss of a draw"""
-    model_class = _MODELS[draw_type]
-
-    obj = model_class.query.filter_by(private_id=id_).first_or_404()
-    obj.toss()
-    models.db.session.add(obj)
-    models.db.session.commit()
-
-    return retrieve_draw_by_id(draw_type, id_)
+class RandomNumber(BaseDrawView):
+    NAME = "random_number"
+    SERIALIZER = schemas.RandomNumber
+    MODEL_CLASS = models.RandomNumber
 
 
-@bp.route("/<string:draw_type>/<string:id_>", methods=["GET"])
-def retrieve_draw_by_id(draw_type, id_):
-    """Retrieves a draw via its public/private id"""
-    serializer = _SCHEMAS[draw_type](exclude=["private_id"])
-    model_class = _MODELS[draw_type]
-
-    obj = model_class.get_draw_or_404(id_)
-    output_data, _ = serializer.dump(obj)
-    return jsonify(output_data)
+RandomNumber.register_urls(bp)


### PR DESCRIPTION
Rather than having the mapping and the free functions, this commits moves the implementation to flask class method based views.

This allows not only to better define the classes linked to a view or draw type but also to customize specific verbs of a draw implementation.

Additionally, as the draw type is not a parameter anymore, a better response is returned in the case where a draw type does not exist.